### PR TITLE
Quickstart Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.6.1
+FROM tiangolo/uwsgi-nginx-flask:python3.6
 
 COPY requirements.txt /
-RUN pip install -r ./requirements.txt
+RUN pip install -r ./requirements.txt --no-cache-dir
 
 COPY app/ /app/
 


### PR DESCRIPTION
Added a better base image from DockerHub.

To reduce space usage on disk, pip installs will happen from PyPI directly.